### PR TITLE
Grip-O-Meter: smooth g-force spikes and add white-to-red background

### DIFF
--- a/Windows/GripOMeterWindow.xaml
+++ b/Windows/GripOMeterWindow.xaml
@@ -56,6 +56,15 @@
                Height="96"
                RenderOptions.BitmapScalingMode="HighQuality" />
 
+        <Border x:Name="GripOMeter_Background"
+                Grid.Row="2"
+                Grid.RowSpan="3"
+                Grid.Column="0"
+                Width="376"
+                Height="88"
+                CornerRadius="44"
+                IsHitTestVisible="False" />
+
         <Border Grid.Row="3"
                 Grid.Column="0"
                 Background="Black"

--- a/Windows/GripOMeterWindow.xaml.cs
+++ b/Windows/GripOMeterWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media;
 
 using PInvoke;
 
@@ -13,6 +14,11 @@ public partial class GripOMeterWindow : Window
 {
 	private bool _initialized = false;
 	private bool _isDraggable = false;
+
+	private float _smoothedSkidSlip = 0f;
+	private float _smoothedSeatOfPants = 0f;
+
+	private const float SmoothingFactor = 0.15f;
 
 	public GripOMeterWindow()
 	{
@@ -134,13 +140,15 @@ public partial class GripOMeterWindow : Window
 	{
 		if ( Visibility == Visibility.Visible )
 		{
-			var offsetX = app.SteeringEffects.SkidSlip * 144f;
+			_smoothedSkidSlip += ( app.SteeringEffects.SkidSlip - _smoothedSkidSlip ) * SmoothingFactor;
+			_smoothedSeatOfPants += ( app.SteeringEffects.SeatOfPantsEffect - _smoothedSeatOfPants ) * SmoothingFactor;
 
-			GripOMeter_Ball_Transform.X = offsetX;
+			GripOMeter_Ball_Transform.X = _smoothedSkidSlip * 144f;
+			GripOMeter_SeatOfPants_Transform.X = _smoothedSeatOfPants * 144f;
 
-			offsetX = app.SteeringEffects.SeatOfPantsEffect * 144f;
-
-			GripOMeter_SeatOfPants_Transform.X = offsetX;
+			var intensity = Math.Abs( _smoothedSkidSlip );
+			var channelValue = (byte) ( 255 * ( 1f - intensity ) );
+			GripOMeter_Background.Background = new SolidColorBrush( Color.FromRgb( 255, channelValue, channelValue ) );
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Two enhancements to the Grip-O-Meter overlay:

**Smoothing**

The ball position now uses an exponential moving average (smoothing factor `0.15`, giving roughly a 100ms time constant at the ~58Hz tick rate) rather than the raw telemetry value. This filters out brief g-force spikes — most notably when going over rumble strips — without introducing noticeable lag during genuine lateral movement. Both the SkidSlip ball and the Seat-of-Pants indicator are smoothed independently.

**White-to-red background**

A dynamically coloured fill is drawn inside the pill outline, behind the balls. The colour interpolates from white (ball centred, zero lateral load) to red (ball at the edge, maximum lateral load) by scaling the G and B channels: `Color.FromRgb(255, (byte)(255 * (1 - intensity)), ...)`. This gives an immediate visual cue of grip usage without needing to track the exact ball position.

## Files changed

- `Windows/GripOMeterWindow.xaml` — adds `GripOMeter_Background` Border element (376×88, CornerRadius 44) between the pill image and the balls in Z-order
- `Windows/GripOMeterWindow.xaml.cs` — adds `_smoothedSkidSlip`, `_smoothedSeatOfPants` fields and `SmoothingFactor` constant; updates `Tick()` to apply smoothing and set the background colour