### PR TITLE
Add --minimized and --tray command line arguments

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -294,11 +294,33 @@ public partial class App : Application
 
 				var showWindow = true;
 
-				if ( DataContext.DataContext.Instance.Settings.AppStartMinimized )
+				var startMinimized = DataContext.DataContext.Instance.Settings.AppStartMinimized;
+				var minimizeToSystemTray = DataContext.DataContext.Instance.Settings.AppMinimizeToSystemTray;
+
+				foreach ( var commandLineArgument in e.Args )
+				{
+					var normalizedArgument = commandLineArgument.TrimStart( '-', '/' ).ToLowerInvariant();
+
+					if ( normalizedArgument is "minimized" or "m" )
+					{
+						startMinimized = true;
+
+						Logger.WriteLine( $"[App] Command line argument '{commandLineArgument}' detected - starting minimized." );
+					}
+					else if ( normalizedArgument is "tray" or "t" )
+					{
+						startMinimized = true;
+						minimizeToSystemTray = true;
+
+						Logger.WriteLine( $"[App] Command line argument '{commandLineArgument}' detected - starting minimized to system tray." );
+					}
+				}
+
+				if ( startMinimized )
 				{
 					MainWindow.WindowState = WindowState.Minimized;
 
-					if ( DataContext.DataContext.Instance.Settings.AppMinimizeToSystemTray )
+					if ( minimizeToSystemTray )
 					{
 						showWindow = false;
 					}


### PR DESCRIPTION
Allows the app to be started minimized (or directly to the system tray) without permanently changing the AppStartMinimized / AppMinimizeToSystemTray settings.

Both args accept '--', '-' and '/' prefixes and short forms 'm' / 't'.