### PR TITLE
Add "Pass FFB through TF4ALL" option (Trueforce haptics + Logitech rev LEDs in iRacing)

### DIFF
--- a/Classes/TF4ALLPassthrough.cs
+++ b/Classes/TF4ALLPassthrough.cs
@@ -1,0 +1,103 @@
+using System.IO.MemoryMappedFiles;
+using System.Threading;
+
+namespace MarvinsAIRARefactored.Classes;
+
+// Writes MAIRA's force + RPM into a shared memory file that TF4ALL
+// (TrueForce-For-All) reads, so TF4ALL can render the force through the
+// Logitech Trueforce ep3 endpoint and drive the rim rev LEDs over HID++.
+//
+// Why: on the Logitech G PRO the rev LEDs (HID++ page 0x807A) and PID
+// force feedback (HID++ page 0x8123) share one command processor on the
+// wheel; when MAIRA streams PID at ~320 Hz, any LED write stalls FFB
+// ~1.5 s (a device-level mutual exclusion, not fixable by software
+// scheduling). With the "Pass FFB signal through TF4ALL" option on,
+// MAIRA stops sending PID to the wheel and publishes its force here
+// instead. No PID on the HID++ pipe => LEDs and FFB no longer fight.
+//
+// Wire format MUST stay byte-identical to TF4ALL's MairaIpcSource
+// (TrueForce-For-All repo, TrueforceForAll.Core/MairaIpcSource.cs):
+// fixed 64-byte map, little-endian, single writer, monotonic sequence
+// written before and after the payload so the reader can detect a torn
+// read.
+
+public sealed class TF4ALLPassthrough : IDisposable
+{
+	private const string MapName = "Local\\TF4ALL_MAIRA_FFB_v1";
+	private const int    MapSize = 64;
+	private const int    Magic   = 0x4D414952; // 'MAIR'
+	private const int    Version = 1;
+
+	// MAIRA publishes ONLY the FFB force. TF4ALL owns the rim LEDs from
+	// its own SimHub telemetry (it is not MAIRA's job to source shift-light
+	// data). Offsets are kept fixed for wire compatibility with TF4ALL's
+	// MairaIpcSource; the rpm/shift slots simply go unused/zero.
+	private const int OffMagic   = 0;
+	private const int OffVersion = 4;
+	private const int OffSeqA    = 8;
+	private const int OffFfbNorm = 16;
+	private const int OffWriteMs = 32;
+	private const int OffSeqB    = 40;
+
+	private MemoryMappedFile? _mmf;
+	private MemoryMappedViewAccessor? _view;
+	private long _seq;
+	private bool _opened;
+
+	private bool EnsureOpen()
+	{
+		if ( _opened )
+		{
+			return true;
+		}
+
+		try
+		{
+			_mmf = MemoryMappedFile.CreateOrOpen( MapName, MapSize, MemoryMappedFileAccess.ReadWrite );
+			_view = _mmf.CreateViewAccessor( 0, MapSize, MemoryMappedFileAccess.ReadWrite );
+			_view.Write( OffMagic, Magic );
+			_view.Write( OffVersion, Version );
+			_opened = true;
+
+			App.Instance?.Logger.WriteLine( "[TF4ALL] FFB passthrough shared memory created." );
+
+			return true;
+		}
+		catch ( Exception exception )
+		{
+			App.Instance?.Logger.WriteLine( $"[TF4ALL] Could not create passthrough shared memory: {exception.Message}" );
+
+			return false;
+		}
+	}
+
+	// ffbNormalized is MAIRA's outputTorque (already torque / MaxForce,
+	// roughly -1..1); TF4ALL maps it to the wheel scale and applies its
+	// own FFB scale/sign. FFB only , nothing else.
+	public void Write( float ffbNormalized )
+	{
+		if ( !EnsureOpen() || _view == null )
+		{
+			return;
+		}
+
+		long seq = ++_seq;
+
+		_view.Write( OffSeqA, seq );
+		Thread.MemoryBarrier();
+		_view.Write( OffFfbNorm, ffbNormalized );
+		_view.Write( OffWriteMs, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() );
+		Thread.MemoryBarrier();
+		_view.Write( OffSeqB, seq );
+	}
+
+	public void Dispose()
+	{
+		try { _view?.Dispose(); } catch { }
+		try { _mmf?.Dispose(); } catch { }
+
+		_view = null;
+		_mmf = null;
+		_opened = false;
+	}
+}

--- a/Components/RacingWheel.cs
+++ b/Components/RacingWheel.cs
@@ -128,7 +128,7 @@ public class RacingWheel
 
 	private readonly GraphBase _algorithmPreviewGraphBase = new();
 
-	private bool _logiPlayLedsNotWorking = false;
+	private readonly TF4ALLPassthrough _tf4allPassthrough = new();
 
 	private int _updateCounter = UpdateInterval + 4;
 	private int _lastGear = 0;
@@ -1411,7 +1411,22 @@ public class RacingWheel
 
 			// update force feedback torque
 
-			app.DirectInput.UpdateForceFeedbackEffect( outputTorque );
+			if ( settings.RacingWheelPassFFBThroughTF4ALL )
+			{
+				// Pass FFB through TF4ALL: do NOT send PID to the wheel.
+				// Publish only the force to TF4ALL, which renders it via the
+				// Trueforce endpoint and owns the rim LEDs from its own
+				// telemetry (no PID on the HID++ pipe => LEDs and FFB stop
+				// fighting). Zero the DInput constant force so no stale PID
+				// torque lingers.
+				_tf4allPassthrough.Write( outputTorque );
+
+				app.DirectInput.UpdateForceFeedbackEffect( 0f );
+			}
+			else
+			{
+				app.DirectInput.UpdateForceFeedbackEffect( outputTorque );
+			}
 
 			// update graph
 
@@ -1475,30 +1490,12 @@ public class RacingWheel
 
 			_racingWheelPage.AutoForce_TextBlock.Text = $"{_autoTorque:F1} {DataContext.DataContext.Instance.Localization[ "TorqueUnits" ]}";
 
-			// update logitech rpm lights
-
-			if ( settings.RacingWheelEnableLogitechRPMLights )
-			{
-				if ( !_logiPlayLedsNotWorking && app.Simulator.IsConnected && ( app.DirectInput.ForceFeedbackJoystick != null ) )
-				{
-					try
-					{
-						if ( !LogitechGSDK.LogiPlayLedsDInput( app.DirectInput.ForceFeedbackJoystick.NativePointer, app.Simulator.RPM, app.Simulator.ShiftLightsFirstRPM, app.Simulator.ShiftLightsShiftRPM ) )
-						{
-							_logiPlayLedsNotWorking = true;
-						}
-					}
-					catch ( Exception )
-					{
-						_logiPlayLedsNotWorking = true;
-					}
-
-					if ( _logiPlayLedsNotWorking )
-					{
-						app.Logger.WriteLine( "[RacingWheel] The Logitech G SDK doesn't seem to be working, so we are temporarily disabling Logitech RPM lights support." );
-					}
-				}
-			}
+			// Rim rev lights: TF4ALL owns them entirely (from its own SimHub
+			// telemetry, over HID++) whenever FFB passthrough is on, which is
+			// the only supported config for Logitech rev lights now. MAIRA no
+			// longer drives the LEDs at all (a second HID++ writer stalls FFB
+			// ~1.5 s per write, a device-level limit), so there is nothing to
+			// do here. The old Logitech-G-SDK path and its toggle were removed.
 
 			// update algorithm preview
 

--- a/DataContext/Settings.cs
+++ b/DataContext/Settings.cs
@@ -2647,19 +2647,26 @@ public class Settings : INotifyPropertyChanged
 
 	#endregion
 
-	#region Racing wheel - Enable Logitech RPM lights
+	#region Racing wheel - Pass FFB signal through TF4ALL
 
-	private bool _racingWheelEnableLogitechRPMLights = true;
+	private bool _racingWheelPassFFBThroughTF4ALL = false;
 
-	public bool RacingWheelEnableLogitechRPMLights
+	// When on (Logitech G PRO / RS50 + TrueForce-For-All), MAIRA stops
+	// sending PID force feedback to the wheel and instead publishes its
+	// force + RPM to TF4ALL via shared memory. TF4ALL renders the force
+	// through the Trueforce endpoint and drives the rim rev LEDs. This is
+	// the only way the rev LEDs and force feedback can coexist on the
+	// G PRO (the wheel serializes LED vs PID writes at the firmware level).
+	// Off = normal MAIRA behaviour (PID FFB straight to the wheel).
+	public bool RacingWheelPassFFBThroughTF4ALL
 	{
-		get => _racingWheelEnableLogitechRPMLights;
+		get => _racingWheelPassFFBThroughTF4ALL;
 
 		set
 		{
-			if ( value != _racingWheelEnableLogitechRPMLights )
+			if ( value != _racingWheelPassFFBThroughTF4ALL )
 			{
-				_racingWheelEnableLogitechRPMLights = value;
+				_racingWheelPassFFBThroughTF4ALL = value;
 
 				OnPropertyChanged();
 			}

--- a/Pages/RacingWheelPage.xaml
+++ b/Pages/RacingWheelPage.xaml
@@ -953,10 +953,38 @@
                                           ContextSwitches="{Binding Settings.RacingWheelFadeEnabledContextSwitches}"
                                           Tag="Complex" />
 
-                    <controls:MairaSwitch Margin="0,10,0,0"
-                                          IsOn="{Binding Settings.RacingWheelEnableLogitechRPMLights, Mode=TwoWay}"
-                                          Label="{Binding Localization[EnableLogitechRPMLights]}"
-                                          Tag="Complex" />
+                    <Grid Margin="0,10,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <controls:MairaSwitch Grid.Column="0"
+                                              HorizontalAlignment="Left"
+                                              IsOn="{Binding Settings.RacingWheelPassFFBThroughTF4ALL, Mode=TwoWay}"
+                                              Label="Pass FFB through TF4ALL for Trueforce haptics + Logitech rev lights"
+                                              Tag="Complex">
+                            <controls:MairaSwitch.ToolTip>
+                                <ToolTip MaxWidth="320">
+                                    <TextBlock TextWrapping="Wrap"
+                                               Text="Routes MAIRA's force feedback through TF4ALL so you also get Trueforce haptics and your rim rev/shift LEDs in iRacing. Needs the free TF4ALL plugin running. Off by default." />
+                                </ToolTip>
+                            </controls:MairaSwitch.ToolTip>
+                        </controls:MairaSwitch>
+
+                        <TextBlock Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   Margin="10,0,0,0"
+                                   Style="{StaticResource MairaTextBlockStyle}">
+                            <Hyperlink NavigateUri="https://github.com/Mhytee/Trueforce-For-All"
+                                       RequestNavigate="Hyperlink_RequestNavigate"
+                                       Foreground="#FF4DA3FF"
+                                       TextDecorations="Underline">
+                                <Run Text="Get TF4ALL" />
+                            </Hyperlink>
+                        </TextBlock>
+                    </Grid>
 
                     <controls:MairaSwitch Margin="0,10,0,0"
                                           IsOn="{Binding Settings.RacingWheelAllowSuperStrength, Mode=TwoWay}"

--- a/Pages/RacingWheelPage.xaml.cs
+++ b/Pages/RacingWheelPage.xaml.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Diagnostics;
+
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -430,6 +432,17 @@ public partial class RacingWheelPage : UserControl
 				SteeringDeviceFaultReason_TextBlock.Visibility = Visibility.Visible;
 			}
 		} );
+	}
+
+	#endregion
+
+	#region Hyperlinks
+
+	private void Hyperlink_RequestNavigate( object sender, System.Windows.Navigation.RequestNavigateEventArgs e )
+	{
+		Process.Start( new ProcessStartInfo( e.Uri.AbsoluteUri ) { UseShellExecute = true } );
+
+		e.Handled = true;
 	}
 
 	#endregion

--- a/docs/TF4ALL-FFB-passthrough.md
+++ b/docs/TF4ALL-FFB-passthrough.md
@@ -1,0 +1,89 @@
+# Why "Pass FFB through TF4ALL" is built this way
+
+This explains the design behind the `RacingWheelPassFFBThroughTF4ALL`
+option, for reviewers and future maintainers.
+
+## The problem
+
+On the Logitech G PRO, the rim rev/shift LEDs and PID force feedback
+both reach the wheel over the same HID++ control path. In testing,
+driving the rev LEDs while MAIRA's PID force feedback was active made
+the wheel drop force feedback for roughly 1 to 1.5 seconds at a time
+(reproduced and measured with USB captures). We could not
+remove it by changing update rate, batching, or threading; it behaves
+like a device-level limit on that shared path. In short, the rev
+lights and PID force feedback could not both run on that path at once.
+
+## The fix: deliver the force as Trueforce, not as PID
+
+The wheel also has a separate Trueforce endpoint, independent of that
+HID++ control path. The key point: to get the rev lights and force
+feedback working together, MAIRA's force has to reach the wheel
+through the Trueforce stream rather than as PID on the shared path.
+
+When passthrough is enabled:
+
+- MAIRA computes its force exactly as before, but no longer sends it
+  to the wheel as PID. Its DirectInput force is pinned to zero and the
+  force value is written into a small shared memory file
+  (`Local\TF4ALL_MAIRA_FFB_v1`, force value only).
+- TF4ALL reads that value, renders it as Logitech Trueforce on the
+  Trueforce endpoint, and drives the rev/shift LEDs from its own
+  telemetry.
+
+With the force delivered as Trueforce instead of as PID, the rev
+lights and force feedback run together. Confirmed on hardware: no
+dropouts.
+
+MAIRA stays the source of truth for force; only the delivery path
+changes, and only when the user opts in.
+
+## Why a standalone Trueforce implementation is required
+
+A fair question is why MAIRA does not just use iRacing's own native
+Trueforce. A MAIRA setup already has the user disable iRacing's force
+feedback, so FFB itself is not the conflict. The conflict is the
+Trueforce endpoint. Delivering MAIRA's force means writing it into the
+Trueforce endpoint. If iRacing's native Trueforce is also enabled,
+iRacing is writing that same endpoint at the same time. Two programs
+writing one endpoint is what produces the 1 to 1.5 second FFB
+dropouts.
+
+So one program has to own the Trueforce endpoint and write both the
+Trueforce signal and the force into it. iRacing's native Trueforce
+stays off, and a standalone Trueforce implementation owns the endpoint
+with MAIRA's force fed into it.
+
+## Why TF4ALL does it (not MAIRA)
+
+MAIRA could build its own Trueforce synthesizer. TF4ALL already has a
+customizable Trueforce effects synthesizer, built and validated on
+hardware. A tiny shared-memory contract (one float, plus a sequence
+for tear-free reads) is far less work and risk than MAIRA duplicating
+the entire Trueforce stack, and keeps responsibilities clean: MAIRA
+does force, TF4ALL does Trueforce delivery and the LEDs.
+
+## Scope and safety
+
+- **Default off, opt-in.** The new switch ships off. With it off,
+  MAIRA sends PID FFB to the wheel exactly as it does today; nothing
+  changes for anyone who does not enable passthrough.
+- **Only changes behavior when passthrough is enabled.** MAIRA's force
+  calculation is unchanged; only the delivery path moves. Turning the
+  switch back off restores normal PID output, no restart needed.
+- **Requires TF4ALL running.** If passthrough is on but TF4ALL is not
+  running, there is simply no force feedback until the user starts
+  TF4ALL or turns passthrough off. It cannot damage the wheel or MAIRA
+  state.
+- **iRacing only.** TF4ALL only consumes the shared memory while
+  iRacing is the active game; the link is inert in other titles.
+- **The old "Enable Logitech RPM lights" option was removed.** In this
+  design TF4ALL drives the rev LEDs; a separate MAIRA-side LED path
+  would conflict with that, so it was removed.
+- **Wheel coverage.** Validated on the Logitech G PRO. The RS50 and
+  G923 use the same Trueforce wire protocol and are expected to behave
+  the same way, but their rev-LED behavior has not yet been
+  hardware-validated.
+
+The byte-level protocol details and capture methodology live in the
+TF4ALL project docs for anyone who wants the full detail.


### PR DESCRIPTION
Opt-in, default off. Adds a `RacingWheelPassFFBThroughTF4ALL` toggle on the Racing Wheel page.

**What it does:** with it on, MAIRA computes force as before but no longer sends it to the wheel as PID (its DirectInput force is pinned to zero); it writes the force value into a small shared memory file. TF4ALL (a free SimHub plugin) reads that, renders it as Logitech Trueforce on the wheel's separate Trueforce endpoint, and drives the rim rev/shift LEDs. iRacing users on a Logitech Trueforce wheel get Trueforce haptics and their rev lights back together, with no FFB dropouts.

**Why this design:** the rev LEDs and PID FFB share one HID++ path on these wheels; driving both at once causes roughly 1 to 1.5 s FFB dropouts. Delivering the force as Trueforce on the separate endpoint instead avoids that. Full rationale is in `docs/TF4ALL-FFB-passthrough.md`.

**Scope and safety:**
- Default off. With it off, MAIRA behaves exactly as today (normal PID); nothing changes for anyone who does not enable it.
- Turning it back off restores normal PID output live, no restart.
- Requires TF4ALL running; if it is not, there is simply no FFB until TF4ALL starts or the toggle is turned off. It cannot damage the wheel or MAIRA state.
- iRacing only.

**Changes:** new `Classes/TF4ALLPassthrough.cs` (shared-memory writer), the toggle (setting plus Racing Wheel page UI with tooltip and a link to TF4ALL), and removal of the old "Enable Logitech RPM lights" option and its LED-driving code (a MAIRA-side LED path recreates the dropout; TF4ALL owns the LEDs in this design).

**Notes:**
- Validated on the Logitech G PRO. The RS50 and G923 use the same Trueforce protocol and are expected to work, but I have not hardware-tested those yet.
- `LogitechGSDK.LogiPlayLedsDInput` is now unused (left in place; your call whether to drop it).
- The new toggle's label and tooltip are hardcoded English, not localized; easy to wire into your localization if you prefer.

Two commits: the feature, and the rationale doc.
